### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CppMT/README.md
+++ b/CppMT/README.md
@@ -5,7 +5,7 @@ Details can be found on the [project page](http://www.gnebehay.com/cmt).
 The implementation in this repository is platform-independent and runs
 on Linux, Windows and OS X.
 
-#License
+# License
 CppMT is freely available under the [Simplified BSD license][1],
 meaning that you can basically do with the code whatever you want.
 If you use our algorithm in scientific work, please cite our publication

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Visual Object Tracking Repository
+# Visual Object Tracking Repository
 
 This repository aims at collecting state-of-the-art tracking algorithms that are freely available.
 In addition, each tracker that is listed here was adapted as to implement a simple standard calling convention

--- a/SCM/README.md
+++ b/SCM/README.md
@@ -1,4 +1,4 @@
-#SCM: Tracking via Sparsity-based Collaborative Model
+# SCM: Tracking via Sparsity-based Collaborative Model
 
 SCM is part of the [Visual Object Tracking Repository](https://github.com/gnebehay/VOTR),
 which aims at providing a central repository for state-of-the-art tracking algorithms that are freely available.
@@ -6,7 +6,7 @@ The source code for this tracker was obtained from its [project site](http://fac
 and extended by a challenge mode.
 The following description was copied literally from the original author.
 
-#Readme
+# Readme
 
 This code is a MATLAB implementation of the tracking algorithm described in CVPR 2012 paper 
         "Robust Object Tracking via Sparsity-based Collaborative Model" 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
